### PR TITLE
Update for Monaco v1.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
-LABEL version="v1.6.0" maintainer="Dynatrace ACE team<ace@dynatrace.com>"
+LABEL version="v1.8.1" maintainer="Dynatrace ACE team<ace@dynatrace.com>"
 
-ARG MAC_VERSION="v1.6.0"
+ARG MAC_VERSION="v1.8.1"
 ENV MONACO_DOWNLOAD_URL=https://github.com/dynatrace-oss/dynatrace-monitoring-as-code/releases/download/${MAC_VERSION}/monaco-linux-amd64
 
 RUN apk add --update --no-cache \


### PR DESCRIPTION
Monaco 1.6.0, 1.7.0, and 1.8.0 all could not be executed within the Alpine Docker container.
This is now fixed with version v1.8.1.