### PR TITLE
Fix indentation of github actions example

### DIFF
--- a/GITHUB.MD
+++ b/GITHUB.MD
@@ -2,7 +2,7 @@
 
 1. Add these GitHub secrets
     * DT_BASE_URL
-    * DT_API_TOKEN 
+    * DT_API_TOKEN
 
 1. This example assumes monaco project files are in the GitHub root folder `monaco`
 
@@ -13,21 +13,21 @@
     workflow_dispatch:
     jobs:
     build:
-        runs-on: ubuntu-latest
-        container:
+      runs-on: ubuntu-latest
+      container:
         image: dynatraceace/monaco-runner:release-v1.6.0
         env:
-            DT_BASEURL: ${{ secrets.DT_BASE_URL }}
-            DT_API_TOKEN: ${{ secrets.DT_API_TOKEN }}
-            NEW_CLI: "1"
+          DT_BASEURL: ${{ secrets.DT_BASE_URL }}
+          DT_API_TOKEN: ${{ secrets.DT_API_TOKEN }}
+          NEW_CLI: "1"
         steps:
         # github automatically creates a volume to the checked out code
         # so we can reference them via ./foldername
         - uses: actions/checkout@v2
-        
+
         - name: Monaco version
-            run: monaco --version 
+          run: monaco --version
 
         - name: Run Monaco
-            run:  monaco deploy -v --environments ./monaco/environments.yml --project dt-orders ./monaco/projects
+          run:  monaco deploy -v --environments ./monaco/environments.yml --project dt-orders ./monaco/projects
     ```


### PR DESCRIPTION
The provided example of a Github action has invalid indentation, causing "The workflow is not valid" messages.